### PR TITLE
Add "placed" enum to RunnerStatus

### DIFF
--- a/betfair/constants.py
+++ b/betfair/constants.py
@@ -62,6 +62,7 @@ RunnerStatus = Enum(
         'REMOVED_VACANT',
         'REMOVED',
         'HIDDEN',
+        'PLACED',
     ]
 )
 


### PR DESCRIPTION
Add missing constant to RunnerStatus as per betfair docs

http://docs.developer.betfair.com/docs/display/1smk3cen4v3lu3yomq5qye0ni/Betting+Enums#BettingEnums-RunnerStatus

Would love this ASAP -- getting lots of errors because of it. Also, happy to be a maintainer on this repo. I use it every day.